### PR TITLE
Switch to custom MT19337 PRNG implementation.

### DIFF
--- a/g_items.c
+++ b/g_items.c
@@ -103,7 +103,7 @@ void DoRespawn (edict_t *ent)
 		for (count = 0, ent = master; ent; ent = ent->chain, count++)
 			;
 
-		choice = genrand_int32() % count;
+		choice = genrand_uniform (count);
 
 		for (count = 0, ent = master; count < choice; ent = ent->chain, count++)
 			;

--- a/g_save.c
+++ b/g_save.c
@@ -135,7 +135,7 @@ void InitGame (void)
 
 	gi.dprintf ("==== InitGame ====\n");
 
-	init_genrand ((unsigned long)time(NULL));
+	init_genrand ((uint32)time(NULL));
 
 	gi.cvar("time_remaining", "N/A", CVAR_SERVERINFO | CVAR_NOSET);
 	gi.cvar("match_type", "N/A", CVAR_SERVERINFO | CVAR_NOSET);

--- a/g_tdm_stats.c
+++ b/g_tdm_stats.c
@@ -1438,7 +1438,7 @@ void TDM_SetupTeamInfoForPlayer (edict_t *ent, teamplayer_t *info)
 		//no prefered code, they get random
 		do
 		{
-			joincode = genrand_int31 () % 9999;
+			joincode = genrand_uniform (9999) + 1;
 		} while (TDM_FindTeamplayerForJoinCode (joincode));
 
 		info->joincode = joincode;

--- a/g_utils.c
+++ b/g_utils.c
@@ -143,7 +143,7 @@ edict_t *G_PickTarget (char *targetname)
 		return NULL;
 	}
 
-	return choice[genrand_int32() % num_choices];
+	return choice[genrand_uniform (num_choices)];
 }
 
 

--- a/mt19937.c
+++ b/mt19937.c
@@ -1,159 +1,107 @@
-/* 
-   A C-program for MT19937, with initialization improved 2002/1/26.
-   Coded by Takuji Nishimura and Makoto Matsumoto.
+/*
+Copyright (C) 1997-2001 Id Software, Inc.
 
-   Before using, initialize the state by using init_genrand(seed)  
-   or init_by_array(init_key, key_length).
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
 
-   Copyright (C) 1997 - 2002, Makoto Matsumoto and Takuji Nishimura,
-   All rights reserved.                          
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 
-   Redistribution and use in source and binary forms, with or without
-   modification, are permitted provided that the following conditions
-   are met:
+See the GNU General Public License for more details.
 
-     1. Redistributions of source code must retain the above copyright
-        notice, this list of conditions and the following disclaimer.
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
-     2. Redistributions in binary form must reproduce the above copyright
-        notice, this list of conditions and the following disclaimer in the
-        documentation and/or other materials provided with the distribution.
-
-     3. The names of its contributors may not be used to endorse or promote 
-        products derived from this software without specific prior written 
-        permission.
-
-   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-   A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
-   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-   EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-   PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-   PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-   LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-   NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-
-   Any feedback is very welcome.
-   http://www.math.sci.hiroshima-u.ac.jp/~m-mat/MT/emt.html
-   email: m-mat @ math.sci.hiroshima-u.ac.jp (remove space)
 */
 
-#include <stdio.h>
+// MT19937 PRNG
 
-/* Period parameters */  
+#include "q_shared.h"
+
 #define N 624
 #define M 397
-#define MATRIX_A 0x9908b0dfUL   /* constant vector a */
-#define UPPER_MASK 0x80000000UL /* most significant w-r bits */
-#define LOWER_MASK 0x7fffffffUL /* least significant r bits */
 
-static unsigned long mt[N]; /* the array for the state vector  */
-static int mti=N+1; /* mti==N+1 means mt[N] is not initialized */
+static uint32 mt_state[N];
+static uint32 mt_index;
 
-/* initializes mt[N] with a seed */
-void init_genrand(unsigned long s)
+/*
+==============
+init_genrand
+
+Seed PRNG with initial value
+==============
+*/
+void init_genrand(uint32 seed)
 {
-    mt[0]= s & 0xffffffffUL;
-    for (mti=1; mti<N; mti++) {
-        mt[mti] = 
-	    (1812433253UL * (mt[mti-1] ^ (mt[mti-1] >> 30)) + mti); 
-        /* See Knuth TAOCP Vol2. 3rd Ed. P.106 for multiplier. */
-        /* In the previous versions, MSBs of the seed affect   */
-        /* only MSBs of the array mt[].                        */
-        /* 2002/01/09 modified by Makoto Matsumoto             */
-        mt[mti] &= 0xffffffffUL;
-        /* for >32 bit machines */
-    }
+	int i;
+
+	mt_index = N;
+	mt_state[0] = seed;
+	for (i = 1; i < N; i++)
+		mt_state[i] = seed = 1812433253 * (seed ^ seed >> 30) + i;
 }
 
-/* initialize by an array with array-length */
-/* init_key is the array for initializing keys */
-/* key_length is its length */
-/* slight change for C++, 2004/2/26 */
-void init_by_array(unsigned long init_key[], int key_length)
-{
-    int i, j, k;
-    init_genrand(19650218UL);
-    i=1; j=0;
-    k = (N>key_length ? N : key_length);
-    for (; k; k--) {
-        mt[i] = (mt[i] ^ ((mt[i-1] ^ (mt[i-1] >> 30)) * 1664525UL))
-          + init_key[j] + j; /* non linear */
-        mt[i] &= 0xffffffffUL; /* for WORDSIZE > 32 machines */
-        i++; j++;
-        if (i>=N) { mt[0] = mt[N-1]; i=1; }
-        if (j>=key_length) j=0;
-    }
-    for (k=N-1; k; k--) {
-        mt[i] = (mt[i] ^ ((mt[i-1] ^ (mt[i-1] >> 30)) * 1566083941UL))
-          - i; /* non linear */
-        mt[i] &= 0xffffffffUL; /* for WORDSIZE > 32 machines */
-        i++;
-        if (i>=N) { mt[0] = mt[N-1]; i=1; }
-    }
+/*
+==============
+genrand_int32
 
-    mt[0] = 0x80000000UL; /* MSB is 1; assuring non-zero initial array */ 
+Generate random integer in range [0, 2^32)
+==============
+*/
+uint32 genrand_int32(void)
+{
+	uint32 x, y;
+	int i;
+
+	if (mt_index >= N) {
+		mt_index = 0;
+
+#define STEP(j, k) do {                 \
+		x  = mt_state[i] & 0x80000000;  \
+		x |= mt_state[j] & 0x7FFFFFFF;  \
+		y  = x >> 1;                    \
+		y ^= 0x9908B0DF & -(x & 1);     \
+		mt_state[i] = mt_state[k] ^ y;  \
+	} while (0)
+
+		for (i = 0; i < N - M; i++)
+			STEP(i + 1, i + M);
+		for (     ; i < N - 1; i++)
+			STEP(i + 1, i - N + M);
+		STEP(0, M - 1);
+	}
+
+	y = mt_state[mt_index++];
+	y ^= y >> 11;
+	y ^= y <<  7 & 0x9D2C5680;
+	y ^= y << 15 & 0xEFC60000;
+	y ^= y >> 18;
+
+	return y;
 }
 
-/* generates a random number on [0,0xffffffff]-interval */
-unsigned long genrand_int32(void)
+/*
+==============
+genrand_uniform
+
+Generate random integer in range [0, n) avoiding modulo bias
+==============
+*/
+uint32 genrand_uniform(uint32 n)
 {
-    unsigned long y;
-    static unsigned long mag01[2]={0x0UL, MATRIX_A};
-    /* mag01[x] = x * MATRIX_A  for x=0,1 */
+	uint32 r, m;
 
-    if (mti >= N) { /* generate N words at one time */
-        int kk;
+	if (n < 2)
+		return 0;
 
-        if (mti == N+1)   /* if init_genrand() has not been called, */
-            init_genrand(5489UL); /* a default initial seed is used */
+	m = -n % n; // m = 2^32 mod n
+	do {
+		r = genrand_int32();
+	} while (r < m);
 
-        for (kk=0;kk<N-M;kk++) {
-            y = (mt[kk]&UPPER_MASK)|(mt[kk+1]&LOWER_MASK);
-            mt[kk] = mt[kk+M] ^ (y >> 1) ^ mag01[y & 0x1UL];
-        }
-        for (;kk<N-1;kk++) {
-            y = (mt[kk]&UPPER_MASK)|(mt[kk+1]&LOWER_MASK);
-            mt[kk] = mt[kk+(M-N)] ^ (y >> 1) ^ mag01[y & 0x1UL];
-        }
-        y = (mt[N-1]&UPPER_MASK)|(mt[0]&LOWER_MASK);
-        mt[N-1] = mt[M-1] ^ (y >> 1) ^ mag01[y & 0x1UL];
-
-        mti = 0;
-    }
-  
-    y = mt[mti++];
-
-    /* Tempering */
-    y ^= (y >> 11);
-    y ^= (y << 7) & 0x9d2c5680UL;
-    y ^= (y << 15) & 0xefc60000UL;
-    y ^= (y >> 18);
-
-    return y;
+	return r % n;
 }
-
-/* generates a random number on [0,0x7fffffff]-interval */
-long genrand_int31(void)
-{
-    return (long)(genrand_int32()>>1);
-}
-
-/* generates a random number on [0,1]-real-interval */
-double genrand_float32_full(void)
-{
-    return genrand_int32()*(1.0/4294967295.0); 
-    /* divided by 2^32-1 */ 
-}
-
-/* generates a random number on [0,1)-real-interval */
-double genrand_float32_notone(void)
-{
-    return genrand_int32()*(1.0/4294967296.0); 
-    /* divided by 2^32 */
-}
-
-/* These real versions are due to Isaku Wada, 2002/01/09 added */

--- a/p_client.c
+++ b/p_client.c
@@ -563,7 +563,7 @@ edict_t *SelectRandomDeathmatchSpawnPoint (void)
 	edict_t	*spot;
 	int		selection;
 
-	selection = genrand_int32() % level.numspawns;
+	selection = genrand_uniform (level.numspawns);
 	spot = level.spawns[selection];
 	return spot;
 }
@@ -622,7 +622,7 @@ void RandomizeArray (void **base, size_t n)
 		size_t i;
 		for (i = 0; i < n - 1; i++)
 		{
-			size_t j = i + genrand_int32() / (0xffffffff / (n - i) + 1);
+			size_t j = i + genrand_uniform (n - i);
 			void *t = base[j];
 			base[j] = base[i];
 			base[i] = t;
@@ -816,7 +816,7 @@ edict_t *SelectRandomDeathmatchSpawnPointAvoidingTwoClosest (void)
 
 	do
 	{
-		selection = genrand_int32() % level.numspawns;
+		selection = genrand_uniform (level.numspawns);
 		spot = level.spawns[selection];
 	} while (spot == spot1 || spot == spot2);
 
@@ -889,7 +889,7 @@ edict_t *SelectRandomDeathmatchSpawnPointAvoidingTwoClosestBugged (void)
 
 	do
 	{
-		selection = genrand_int32() % level.numspawns;
+		selection = genrand_uniform (level.numspawns);
 		spot = level.spawns[selection];
 	} while (spot == spot1 || spot == spot2);
 

--- a/q_shared.h
+++ b/q_shared.h
@@ -192,25 +192,12 @@ typedef enum {false, true}	qboolean;
 //r1: set this to 1 if you have a stupid endian thingy
 #define Q_BIGENDIAN 0
 
-#define random()		(genrand_float32_full())	// 0..1
-#define random2()		(genrand_float32_notone())	// 0..1
+#define random()	((int32)genrand_int32() * (1.0f / 4294967296.0f) + 0.5f)	//  0..1
+#define crandom()	((int32)genrand_int32() * (1.0f / 2147483648.0f))			// -1..1
 
-#define brandom(a,b)	((a)+random()*((b)-(a)))				// a..b
-#define crandom()		brandom(-1,1)							// -1..1 
-
-int		Q_rand (int *seed);
-#define Q_random(seed)		((Q_rand (seed) & 0x7fff) / ((float)0x7fff))	// 0..1
-#define Q_brandom(seed,a,b)	((a)+Q_random(seed)*((b)-(a)))						// a..b
-#define Q_crandom(seed)		Q_brandom(seed,-1,1)
-
-unsigned long genrand_int32(void);
-long genrand_int31(void);
-double genrand_float32_full(void);
-double genrand_float32_notone(void);
-void init_genrand(unsigned long s);
-
-//#define	frand()		(random())
-//#define	crand()		(((int)randomMT() - 0x7FFFFFFF) * 0.000000000465661287307739257812f)
+void init_genrand(uint32 s);
+uint32 genrand_int32(void);
+uint32 genrand_uniform(uint32 n);
 
 #ifndef NULL
 #define NULL ((void *)0)


### PR DESCRIPTION
Original code used ‘long’ where 32-bit integers are enough. This can be
a problem on LP64. Switch to custom MT19337 PRNG implementation adapted
by myself from algorithm pseudo-code that is functionally equivalent but
doesn't use ‘long’.

Add genrand_uniform() function that generates uniformly distributed
random integers modulo N, and use it in place of naive calculations.
This function uses the trick adapted from OpenBSD implementation of
arc4random_uniform() to calculate 2^32 modulo N.