### PR TITLE
Add sending hit info

### DIFF
--- a/g_combat.c
+++ b/g_combat.c
@@ -398,6 +398,14 @@ void T_Damage(edict_t *targ, edict_t *inflictor, edict_t *attacker, vec3_t dir,
 
         targ->health = targ->health - take;
 
+        // send hit marker to attacker
+        if (attacker && attacker->client && attacker != targ) {
+            gi.WriteByte(SVC_TEMP_ENTITY);
+            gi.WriteByte(TE_DAMAGE_DEALT);
+            gi.WriteShort(take);
+            gi.unicast(attacker, false);
+        }
+
         if (targ->health <= 0) {
             if ((targ->svflags & SVF_MONSTER) || (client)) {
                 targ->flags |= FL_NO_KNOCKBACK;

--- a/q_shared.h
+++ b/q_shared.h
@@ -1130,8 +1130,10 @@ typedef enum {
     TE_WIDOWSPLASH,
     TE_EXPLOSION1_BIG,
     TE_EXPLOSION1_NP,
-    TE_FLECHETTE
+    TE_FLECHETTE,
     //ROGUE
+
+    TE_DAMAGE_DEALT = 128,
 } temp_event_t;
 
 #define SPLASH_UNKNOWN          0


### PR DESCRIPTION
Requires proper q2pro version with "cl_hit_markers" option turned on and image "pics/marker.png" see the effect.