### PR TITLE
Add damage indicators

### DIFF
--- a/g_local.h
+++ b/g_local.h
@@ -1521,6 +1521,7 @@ struct gclient_s {
     int            damage_blood;    // damage taken out of health
     int            damage_knockback; // impact damage
     vec3_t         damage_from;     // origin for vector calculation
+    int            damage_indicator_count;
 
     float          killer_yaw;      // when dead, look at killer
 

--- a/p_view.c
+++ b/p_view.c
@@ -81,6 +81,14 @@ void P_DamageFeedback(edict_t *player) {
         return;     // didn't take any damage
     }
 
+    VectorSubtract(client->damage_from, player->s.origin, v);
+    VectorNormalize(v);
+    int yaw = (int)(180.0f * atan2f(DotProduct(v, right), DotProduct(v, forward)) / M_PI + 0.5f);
+    if (yaw < 0) {
+        yaw += 360;
+    }
+    client->ps.stats[STAT_FLASHES] |= ((yaw & 511) << 2) | ((++client->damage_indicator_count & 15) << 11);
+
     // start a pain animation if still in the player model
     if (client->anim_priority < ANIM_PAIN && player->s.modelindex == 255) {
         static int i;
@@ -169,8 +177,6 @@ void P_DamageFeedback(edict_t *player) {
             kick = 50;
         }
 
-        VectorSubtract(client->damage_from, player->s.origin, v);
-        VectorNormalize(v);
         side = DotProduct(v, right);
         client->v_dmg_roll = kick * side * 0.3f;
         side = -DotProduct(v, forward);


### PR DESCRIPTION
Modified q2pro with "scr_damage_indicator" turned on is required. Similar functionality to one seen in Remaster.